### PR TITLE
Deprecated 라이브러리 교체 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
 			<artifactId>commons-codec</artifactId>
 			<version>1.4</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<version>1.9</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/nhncorp/lucy/security/xss/XssPreventer.java
+++ b/src/main/java/com/nhncorp/lucy/security/xss/XssPreventer.java
@@ -18,7 +18,7 @@ package com.nhncorp.lucy.security.xss;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 

--- a/src/main/java/com/nhncorp/lucy/security/xss/XssPreventer.java
+++ b/src/main/java/com/nhncorp/lucy/security/xss/XssPreventer.java
@@ -45,7 +45,7 @@ public class XssPreventer {
 
 	private static final Log LOG = LogFactory.getLog(XssFilter.class);
 	private static Pattern escapePattern = Pattern.compile("'");
-	private static Pattern unescapePttern = Pattern.compile("&#39;");
+	private static Pattern unescapePattern = Pattern.compile("&#39;");
 
 	/**
 	 * 이 메소드는 XSS({@code Cross Site Scripting})가 포함된 위험한 코드에 대하여
@@ -88,7 +88,7 @@ public class XssPreventer {
 			return null;
 		}
 
-		Matcher matcher = unescapePttern.matcher(str);
+		Matcher matcher = unescapePattern.matcher(str);
 
 		if (matcher.find()) {
 			return matcher.replaceAll("'");


### PR DESCRIPTION
[commons-lang3 StringEscapeUtils](https://commons.apache.org/proper/commons-lang/apidocs/org/apache/commons/lang3/StringEscapeUtils.html) 대신 [commons-text StringEscapeUtils](https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StringEscapeUtils.html)를 사용하도록 작업했습니다.

Apache Commons Lang 3.6. 부터는 commons-lang3 StringEscapeUtils 가 deprecated 되어 commons-text StringEscapeUtils 를 사용하도록 가이드 되고 있습니다.  
> Deprecated. as of 3.6, use commons-text StringEscapeUtils instead 


그리고 오타를 발견해서 수정했습니다.  