### PR TITLE
blockingPrefix 설정 내용 추가

### DIFF
--- a/docs/kr/rule-config.adoc
+++ b/docs/kr/rule-config.adoc
@@ -144,6 +144,15 @@ ContentsRemoveListener는 XssFilter 객체일 경우에만 사용 가능하다. 
 
 IEHackExtension은 Element를 상속 받은 클래스로서 Element에서 사용하는 속성 및 메소드 모두 사용 가능하다.
 
+== blockingPrefix
+
+Lucy-XSS Filter에서는 화이트리스트에 포함되지 않은 부분에 대해 `<`, `>` 를 `&#38;&#108;&#116;&#59;`, `&#38;&#103;&#116;&#59;` 로 치환하지 않고 태그에 prefix를 적용할 수 있다. 아래 설정을 적용하면 허용되지 않은 `<notAllowed>` 태그를 `<xnotAllowed>` 로 치환한다.
+
+[source,xml]
+----
+<blockingPrefix enable="true" prefix="x"/>
+----
+
 == filteringTagInComment
 Lucy-XSS Filter에서는 HTML 주석(<!-- 주석문 -->)내에 존재하는 HTML 태그에 대해서 XSS 필터링 여부를 설정하고 타입을 지정할 수 있다.
 설정을 명시하지 않은 경우, 주석 내에 존재하는 괄호 `<` , `>` 은 `&#38;&#108;&#116;&#59;` , `&#38;&#103;&#116;&#59;` 으로 변환하는 것을 디폴트로 한다.


### PR DESCRIPTION
`blockingPrefix`는 메일 솔루션 등에 유용한 기능임에도 문서화가 되어있지 않습니다.
- 내부 코드를 보고 해당 기능을 알게 되었습니다.

Guide 문서에 해당 부분 내용을 추가합니다.

감사합니다.