### PR TITLE
SSRF 이슈 및 자바 버전 정보 노출 수정 (checkVulnerableWithHttp)

### DIFF
--- a/src/main/java/com/nhncorp/lucy/security/xss/listener/SecurityUtils.java
+++ b/src/main/java/com/nhncorp/lucy/security/xss/listener/SecurityUtils.java
@@ -157,8 +157,10 @@ public class SecurityUtils {
 				}
 
 				if (StringUtils.isEmpty(extension)) {
-					// 확장자가 없어서 MIME TYPE 을 식별할 수 없으면, 해당 url 을 head HTTP Method 를 이용해 content-type 식별
-					type = getContentTypeFromUrlConnection(url, contentTypeCacheRepo);
+					// URLConnection을 통해 Mimetype을 결정하면 SSRF 취약점 / JDK 버전 정보 노출이 발생합니다. 
+					// 입력 받은 URL을 통해 Type을 결정하기 힘든 경우, default로 'application/octet-stream'로 설정합니다.
+					//type = getContentTypeFromUrlConnection(url, contentTypeCacheRepo);
+					type = "application/octet-stream";
 
 					//허용된 type 인가?
 					if (!isAllowedType(type)) {


### PR DESCRIPTION
안녕하세요. 

lucy-xss-filter에서 SSRF 및 자바 버전 정보 노출 이슈를 확인하여 수정 PR을 생성해보았습니다. 

내용 검토 부탁드리겠습니다. 

# 공격 발생 조건 
해당 이슈는 checkVulnerableWithHttp에서 발생합니다. 

checkVulnerableWithHttp는 ObjectSecurityListener 또는 EmbedSecurityListener 옵션이 활성화되어 있을때, 
lucy-xss-filter에서 내부적으로 호출합니다. 

# 공격 검증
해당 이슈를 테스트해볼 수 있는 코드를 작성하였습니다. (https://github.com/ksw9722/lucy-xss-tester)
https://github.com/ksw9722/lucy-xss-tester/blob/main/src/main/java/LucyConsoleTest.java#L10에서 object src의 URL을 HTTP 요청을 받을 서버로 변경하시고, 실행하시면 테스트할 수 있습니다. 
![image](https://github.com/user-attachments/assets/4e3ea816-836f-41aa-9bfe-354a918a30fd)

위 테스트 코드를 실행하시면, 아래와 같이 lucy xss filter에서 HEAD HTTP 요청이 공격자의 서버로 발생합니다. 
lucy-xss-filter가 적용된 서버에서 발생한 HTTP 요청이므로, 해당 취약점은 [SSRF](https://www.f5.com/ko_kr/glossary/ssrf)로 분류될 수 있습니다.  

또한 USER-AGENT를 통해 서버에서 사용중인 Java 버전도 노출되고 있습니다. 
![image](https://github.com/user-attachments/assets/b2e84c5b-11d0-4684-a85f-a20a4984cff8)

# 해당 이슈의 파급력?
**- Object/Embed SecurityListner가 활성화되어 있는 환경에서만 발생합니다.** 
- 취약점이 악용될 경우 서버의 Java 버전이 공격자에게 노출됩니다. (서버 정보 노출)
- 공격자는 서버의 internal 서버로 임의로 HEAD 요청을 전달할 수 있습니다. lucy가 설정된 서버를 프록시처럼 사용하여 내부망에 진입할 수 있습니다. 
-> HEAD 메소드는 GET과 동일하게 데이터 조회 용도로만 사용되나, GET/HEAD로 상태 변경하는 기능을 내부망에서 제공할 경우 악용될 수 있습니다. 
-> 내부망에 아래와 같이 느슨하게 설정된 HTTP 핸들러가 있을 경우, 공격자에 의해 악용될 수 있습니다.
```
import org.springframework.web.bind.annotation.RequestMapping;
import org.springframework.web.bind.annotation.RequestParam;
import org.springframework.web.bind.annotation.RestController;

@RestController
public class UniversalController {

    @RequestMapping("/api/universal") // 모든 HTTP 메소드 지원
    public String handleAllMethods(@RequestParam(required = false) String param) {
        if (param != null) {
            //Act Anything
        }
        return "No parameter provided.";
    }
}
```

# 대응 방안
MimeType 동적 판단을 위해 사용하는 checkVulnerableWithHttp는 위와 같은 취약점을 유발할 수 밖에 없는 구조입니다. 
따라서 MimeType을 입력 받은 URL을 통해서 확인이 힘든 경우, HTTP요청을 발생시켜서 MimeType을 확인하지 않고, 
고정된 값으로 사용 검토 부탁드립니다. ex) 'application/ocact-stream 등'

감사합니다. 